### PR TITLE
Disable sending spans but leave as placeholder for future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # ghost_actor changelog
 
-## 0.3.0
+## 0.2.1
 
--
+- [#35](https://github.com/holochain/ghost_actor/pull/35) - Tracing spans were erroneously crossing awaits, disabled until we find a better solution.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ghost_actor changelog
 
+## 0.3.0
+
+-
+
 ## 0.2.0
 
 - [#31](https://github.com/holochain/ghost_actor/pull/31) - `handle_ghost_actor_shutdown` is now async

--- a/crates/ghost_actor/Cargo.toml
+++ b/crates/ghost_actor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghost_actor"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "A simple, ergonomic, idiomatic, macro for generating the boilerplate to use rust futures tasks in a concurrent actor style."
@@ -16,6 +16,7 @@ futures = "0.3"
 paste = "0.1.12"
 thiserror = "1"
 tracing = "0.1"
+tracing-futures = "0.2"
 must_future = "0.1.2"
 
 [dev-dependencies]

--- a/crates/ghost_actor/Cargo.toml
+++ b/crates/ghost_actor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghost_actor"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "A simple, ergonomic, idiomatic, macro for generating the boilerplate to use rust futures tasks in a concurrent actor style."

--- a/crates/ghost_actor/Cargo.toml
+++ b/crates/ghost_actor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghost_actor"
-version = "0.3.0-alpha.2"
+version = "0.2.1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "A simple, ergonomic, idiomatic, macro for generating the boilerplate to use rust futures tasks in a concurrent actor style."

--- a/crates/ghost_actor/src/actor_builder.rs
+++ b/crates/ghost_actor/src/actor_builder.rs
@@ -169,7 +169,7 @@ impl<H: GhostControlHandler> GhostActorBuilder<H> {
                 // Check if we have any new streams to inject.
                 let to_inject = inject.drain().await?;
                 if !to_inject.is_empty() {
-                    stream_multiplexer = Some(
+                    let mut stream_multiplexer = Some(
                         stream_multiplexer_chunks.take().unwrap().into_inner(),
                     );
                     for i in to_inject {

--- a/crates/ghost_actor/src/lib.rs
+++ b/crates/ghost_actor/src/lib.rs
@@ -260,6 +260,7 @@ pub mod dependencies {
     pub use paste;
     pub use thiserror;
     pub use tracing;
+    pub use tracing_futures;
 }
 
 mod types;

--- a/crates/ghost_actor/src/types.rs
+++ b/crates/ghost_actor/src/types.rs
@@ -89,7 +89,7 @@ impl<T: 'static + Send> GhostRespond<T> {
         // As a responder, we don't care.
         let _ = self
             .0
-            .send((t, tracing::debug_span!("respond", "{}", self.1)));
+            .send((t, tracing::Span::none()));
     }
 
     /// For those who simply cannot stand typing `respond.respond()`,

--- a/crates/ghost_actor/src/types.rs
+++ b/crates/ghost_actor/src/types.rs
@@ -87,9 +87,7 @@ impl<T: 'static + Send> GhostRespond<T> {
         // In a ghost channel, the only error you can get is that the sender
         // is no longer available to receive the response.
         // As a responder, we don't care.
-        let _ = self
-            .0
-            .send((t, tracing::Span::none()));
+        let _ = self.0.send((t, tracing::Span::none()));
     }
 
     /// For those who simply cannot stand typing `respond.respond()`,


### PR DESCRIPTION
## Don't create spans where they are not entered or enter spans across awaits 
So sending Spans through channels breaks tracing because it means the span is open from when it's created but might not be entered until it arrives.
This leads to really misleading readings because it looks like where the span is entered is much larger then what it really spans.
Basically it spans the whole send process. I can see in a way why we might want to represent it this way but it makes it hard to find the source of back pressure.
You don't really want to know how long it took some data to get to the destination, you only want to know if the send had to wait to actually send the data.
It makes it a lot easier to track down bottlenecks if you can see a send that is always awaiting.

## Measuring channel latency 
The latency on an rpc is the combo of the send future and the response future which can easily be measured by a parent span over the two.

The other case of send and forget is a little harder but maybe we don't need this metric due to back pressure.
The latency is the send future plus recv future for the same item. This requires some form of causal relationship between the two.

## Maintaining the causal relationship 
I have left the spans in the same locations but set to `none()` as a placeholder to find a way to represent this.
I think we probably want to extract some information from the metadata of the current span on the sending side and then add it to the span that does the work on the recv side.

It's hard to know what we want without knowing how we want to represent the follows from relationship.
You could look at an rpc as parent on the send side and a recv on the child side by sending through the `span::current()` then making a span on the recv side as the child of the parent but it only works if the rpc span really is alive until after the response comes back.
For a send and forget this doesn't work as the "parent" has been dropped before the child. We might instead save the name / file / line number and fields then record them on the recv side span.